### PR TITLE
feat(db): baseline Alembic migration for users and projects [REN-86]

### DIFF
--- a/alembic/versions/0001_baseline_users_projects.py
+++ b/alembic/versions/0001_baseline_users_projects.py
@@ -1,0 +1,137 @@
+# Copyright 2025 ByBren, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Baseline migration: create users and projects tables.
+
+Revision ID: 0001_baseline
+Revises: None
+Create Date: 2026-03-09
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0001_baseline"
+down_revision: str | None = None
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create users and projects tables."""
+    # -- users ----------------------------------------------------------------
+    op.create_table(
+        "users",
+        sa.Column(
+            "id",
+            sa.Uuid(),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "email",
+            sa.String(length=255),
+            unique=True,
+            nullable=False,
+        ),
+        sa.Column(
+            "name",
+            sa.String(length=255),
+            nullable=False,
+        ),
+        sa.Column(
+            "hashed_password",
+            sa.String(length=255),
+            nullable=False,
+        ),
+        sa.Column(
+            "is_active",
+            sa.Boolean(),
+            server_default=sa.text("true"),
+            nullable=False,
+        ),
+        sa.Column(
+            "is_admin",
+            sa.Boolean(),
+            server_default=sa.text("false"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+    )
+    op.create_index("ix_users_email", "users", ["email"], unique=True)
+
+    # -- projects -------------------------------------------------------------
+    op.create_table(
+        "projects",
+        sa.Column(
+            "id",
+            sa.Uuid(),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "name",
+            sa.String(length=255),
+            nullable=False,
+        ),
+        sa.Column(
+            "description",
+            sa.Text(),
+            nullable=True,
+        ),
+        sa.Column(
+            "owner_id",
+            sa.Uuid(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+    )
+    op.create_index("ix_projects_owner_id", "projects", ["owner_id"])
+
+
+def downgrade() -> None:
+    """Drop projects and users tables (projects first due to FK dependency)."""
+    op.drop_index("ix_projects_owner_id", table_name="projects")
+    op.drop_table("projects")
+    op.drop_index("ix_users_email", table_name="users")
+    op.drop_table("users")


### PR DESCRIPTION
## Summary
- Creates initial Alembic migration (`0001_baseline_users_projects.py`) for the `users` and `projects` tables
- Matches existing SQLAlchemy models in `core/models/base.py`
- Proper `downgrade()` drops tables in FK-dependency order (projects first, then users)

## Changes
- `alembic/versions/0001_baseline_users_projects.py` — new migration file (137 LOC)

## Linear
Closes REN-86

## Test plan
- [ ] `alembic upgrade head` creates both tables with correct schema
- [ ] `alembic downgrade base` drops both tables cleanly
- [ ] `alembic current` shows `0001_baseline` after upgrade
- [ ] Foreign key constraint on `projects.owner_id` enforced

🤖 Generated with [Claude Code](https://claude.com/claude-code)