### PR TITLE
fix(security): migrate legacy files from PyJWT to python-jose [REN-66]

### DIFF
--- a/core/ledger/vault/token_rotator.py
+++ b/core/ledger/vault/token_rotator.py
@@ -1,9 +1,32 @@
+# Copyright 2025 ByBren, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Edge-node token rotation service.
+
+Generates short-lived JWTs for edge nodes and stores them in HashiCorp Vault.
+Tokens are rotated on demand via the ``/rotate`` endpoint.
+"""
+
 import datetime
 import os
 
 import hvac
-import jwt
+import structlog
 from fastapi import FastAPI
+from jose import jwt
+
+logger = structlog.get_logger(__name__)
 
 app = FastAPI()
 VAULT = hvac.Client(url="http://vault:8200", token=os.environ["VAULT_TOKEN"])
@@ -12,14 +35,28 @@ JWT_SECRET = os.environ["JWT_SIGNING_KEY"]
 
 @app.post("/rotate")
 async def rotate(node_id: str):
+    """Rotate the JWT for a given edge node.
+
+    Creates a new 24-hour token, stores it in Vault, and returns it to the caller.
+
+    Args:
+        node_id: Unique identifier of the edge node requesting rotation.
+
+    Returns:
+        Dictionary containing the newly issued JWT.
+    """
+    now = datetime.datetime.now(tz=datetime.UTC)
     token = jwt.encode(
         {
             "sub": node_id,
-            "iat": datetime.datetime.utcnow(),
-            "exp": datetime.datetime.utcnow() + datetime.timedelta(hours=24),
+            "iat": now,
+            "exp": now + datetime.timedelta(hours=24),
         },
         JWT_SECRET,
         algorithm="HS256",
     )
-    VAULT.secrets.kv.v2.create_or_update_secret(path=f"edge/{node_id}", secret={"token": token})
+    VAULT.secrets.kv.v2.create_or_update_secret(
+        path=f"edge/{node_id}", secret={"token": token}
+    )
+    logger.info("edge_token_rotated", node_id=node_id)
     return {"token": token}

--- a/edgekit/poller/core/fleet_gateway.py
+++ b/edgekit/poller/core/fleet_gateway.py
@@ -1,9 +1,9 @@
 import datetime
 import os
 
-import jwt
-from fastapi import FastAPI, Header
+from fastapi import FastAPI, Header, HTTPException
 from influxdb_client import InfluxDBClient, Point
+from jose import JWTError, jwt
 
 app = FastAPI()
 client = InfluxDBClient(url="http://influxdb:8086", token="root:root", org="wtfb")
@@ -15,7 +15,7 @@ SECRET = os.getenv("FLEET_JWT_SECRET", "changeme")
 def auth_check(tok):
     try:
         return jwt.decode(tok.split()[1], SECRET, algorithms=["HS256"])["sub"]
-    except Exception:
+    except JWTError:
         raise HTTPException(status_code=401)
 
 
@@ -25,6 +25,6 @@ async def hb(stats: dict, authorization: str = Header(...)):
     p = Point("gpuFleet").tag("node", node)
     for k, v in stats.items():
         p = p.field(k, v)
-    p = p.time(datetime.datetime.utcnow())
+    p = p.time(datetime.datetime.now(tz=datetime.UTC))
     write.write("gpu", record=p)
     return {"ok": True}


### PR DESCRIPTION
## Summary
- Migrate 2 legacy files from PyJWT (`import jwt`) to python-jose (`from jose import jwt`), matching the project standard in `core/auth/jwt.py`
- Fix bare `except Exception` to `except JWTError` in `edgekit/poller/core/fleet_gateway.py`
- Fix deprecated `datetime.utcnow()` to `datetime.now(tz=UTC)` (DTZ003) in both files
- Add missing `HTTPException` import in fleet_gateway (was used but never imported)
- Add Apache 2.0 license header, docstrings, and structlog logger to `core/ledger/vault/token_rotator.py`

## Files changed
- `edgekit/poller/core/fleet_gateway.py` -- JWT import migration, JWTError catch, datetime fix, HTTPException import
- `core/ledger/vault/token_rotator.py` -- JWT import migration, datetime fix, license header, structlog, docstrings

## Test plan
- [x] Verify `from jose import jwt` in both files (no bare `import jwt` in production code)
- [x] `ruff check` passes on both modified files
- [x] No PyJWT imports remain outside documentation files
- [ ] Integration test: fleet_gateway heartbeat endpoint accepts valid JWT
- [ ] Integration test: token_rotator issues valid python-jose JWT

🤖 Generated with [Claude Code](https://claude.com/claude-code)