### PR TITLE
feat(db): add CreditLedgerEntry model and migration [REN-75]

### DIFF
--- a/alembic/versions/0002_add_credit_ledger_entries.py
+++ b/alembic/versions/0002_add_credit_ledger_entries.py
@@ -1,0 +1,147 @@
+# Copyright 2025 ByBren, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Add credit_ledger_entries table.
+
+Revision ID: 0002_credit_ledger
+Revises: 0001_baseline
+Create Date: 2026-03-09
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0002_credit_ledger"
+down_revision: str | None = "0001_baseline"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# PostgreSQL native ENUM types
+transaction_direction = sa.Enum(
+    "CREDIT",
+    "DEBIT",
+    name="transaction_direction",
+)
+transaction_source = sa.Enum(
+    "STRIPE",
+    "USAGE",
+    "ADJUSTMENT",
+    "REFUND",
+    name="transaction_source",
+)
+
+
+def upgrade() -> None:
+    """Create credit_ledger_entries table with enum types and constraints."""
+    # -- enum types -----------------------------------------------------------
+    transaction_direction.create(op.get_bind(), checkfirst=True)
+    transaction_source.create(op.get_bind(), checkfirst=True)
+
+    # -- credit_ledger_entries ------------------------------------------------
+    op.create_table(
+        "credit_ledger_entries",
+        sa.Column(
+            "id",
+            sa.Uuid(),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "user_id",
+            sa.Uuid(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "amount",
+            sa.Numeric(precision=12, scale=4),
+            nullable=False,
+        ),
+        sa.Column(
+            "direction",
+            transaction_direction,
+            nullable=False,
+        ),
+        sa.Column(
+            "source",
+            transaction_source,
+            nullable=False,
+        ),
+        sa.Column(
+            "reference_id",
+            sa.String(length=255),
+            nullable=False,
+        ),
+        sa.Column(
+            "balance_after",
+            sa.Numeric(precision=12, scale=4),
+            nullable=False,
+        ),
+        sa.Column(
+            "description",
+            sa.Text(),
+            nullable=True,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.UniqueConstraint(
+            "reference_id",
+            "direction",
+            name="uq_ledger_reference_direction",
+        ),
+        sa.CheckConstraint(
+            "balance_after >= 0",
+            name="ck_ledger_balance_non_negative",
+        ),
+    )
+    op.create_index(
+        "ix_credit_ledger_entries_user_id",
+        "credit_ledger_entries",
+        ["user_id"],
+    )
+    op.create_index(
+        "ix_credit_ledger_entries_reference_id",
+        "credit_ledger_entries",
+        ["reference_id"],
+    )
+
+
+def downgrade() -> None:
+    """Drop credit_ledger_entries table and enum types."""
+    op.drop_index(
+        "ix_credit_ledger_entries_reference_id",
+        table_name="credit_ledger_entries",
+    )
+    op.drop_index(
+        "ix_credit_ledger_entries_user_id",
+        table_name="credit_ledger_entries",
+    )
+    op.drop_table("credit_ledger_entries")
+    transaction_source.drop(op.get_bind(), checkfirst=True)
+    transaction_direction.drop(op.get_bind(), checkfirst=True)

--- a/core/models/__init__.py
+++ b/core/models/__init__.py
@@ -18,6 +18,20 @@ Import all models here so Alembic autogenerate can discover them.
 """
 
 from core.database import Base, BaseModel
-from core.models.base import Project, User
+from core.models.base import (
+    CreditLedgerEntry,
+    Project,
+    TransactionDirection,
+    TransactionSource,
+    User,
+)
 
-__all__ = ["Base", "BaseModel", "Project", "User"]
+__all__ = [
+    "Base",
+    "BaseModel",
+    "CreditLedgerEntry",
+    "Project",
+    "TransactionDirection",
+    "TransactionSource",
+    "User",
+]

--- a/core/models/base.py
+++ b/core/models/base.py
@@ -14,13 +14,24 @@
 
 """Core domain models for RenderTrust.
 
-Defines the foundational User and Project models.
+Defines the foundational User, Project, and CreditLedgerEntry models.
 All models use UUID primary keys and include created_at/updated_at timestamps.
 """
 
+import enum
 import uuid
+from decimal import Decimal
 
-from sqlalchemy import Boolean, ForeignKey, String, Text
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    Enum,
+    ForeignKey,
+    Numeric,
+    String,
+    Text,
+    UniqueConstraint,
+)
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from core.database import BaseModel
@@ -108,3 +119,89 @@ class Project(BaseModel):
 
     def __repr__(self) -> str:
         return f"<Project(id={self.id}, name={self.name})>"
+
+
+class TransactionDirection(enum.Enum):
+    """Direction of a credit ledger transaction."""
+
+    CREDIT = "CREDIT"
+    DEBIT = "DEBIT"
+
+
+class TransactionSource(enum.Enum):
+    """Source/reason for a credit ledger transaction."""
+
+    STRIPE = "STRIPE"
+    USAGE = "USAGE"
+    ADJUSTMENT = "ADJUSTMENT"
+    REFUND = "REFUND"
+
+
+class CreditLedgerEntry(BaseModel):
+    """Credit ledger entry tracking user credit transactions.
+
+    Implements double-entry style tracking with idempotency via
+    UNIQUE(reference_id, direction) constraint.
+
+    Attributes:
+        user_id: FK to the owning User.
+        amount: Transaction amount (positive value).
+        direction: CREDIT or DEBIT.
+        source: Origin of the transaction (STRIPE, USAGE, ADJUSTMENT, REFUND).
+        reference_id: External reference for idempotency (e.g. Stripe charge ID).
+        balance_after: User's credit balance after this transaction.
+        description: Optional human-readable description.
+        user: Relationship to the User who owns this entry.
+    """
+
+    __tablename__ = "credit_ledger_entries"
+    __table_args__ = (
+        UniqueConstraint(
+            "reference_id",
+            "direction",
+            name="uq_ledger_reference_direction",
+        ),
+        CheckConstraint(
+            "balance_after >= 0",
+            name="ck_ledger_balance_non_negative",
+        ),
+    )
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    amount: Mapped[Decimal] = mapped_column(
+        Numeric(12, 4),
+        nullable=False,
+    )
+    direction: Mapped[TransactionDirection] = mapped_column(
+        Enum(TransactionDirection, name="transaction_direction"),
+        nullable=False,
+    )
+    source: Mapped[TransactionSource] = mapped_column(
+        Enum(TransactionSource, name="transaction_source"),
+        nullable=False,
+    )
+    reference_id: Mapped[str] = mapped_column(
+        String(255),
+        nullable=False,
+        index=True,
+    )
+    balance_after: Mapped[Decimal] = mapped_column(
+        Numeric(12, 4),
+        nullable=False,
+    )
+    description: Mapped[str | None] = mapped_column(
+        Text,
+        nullable=True,
+    )
+
+    user: Mapped["User"] = relationship("User")
+
+    def __repr__(self) -> str:
+        return (
+            f"<CreditLedgerEntry(id={self.id}, user_id={self.user_id}, "
+            f"amount={self.amount}, direction={self.direction.value})>"
+        )


### PR DESCRIPTION
## Summary
- Add `CreditLedgerEntry` SQLAlchemy model to `core/models/base.py` with `TransactionDirection` and `TransactionSource` enums
- Add Alembic migration `0002_credit_ledger` creating `credit_ledger_entries` table with PostgreSQL native ENUM types
- Includes idempotency constraint (`UNIQUE(reference_id, direction)`) and non-negative balance `CHECK` constraint

## Test plan
- [ ] Model imports without error (`from core.models import CreditLedgerEntry`)
- [ ] Migration file has correct revision chain (`0001_baseline` -> `0002_credit_ledger`)
- [ ] `ruff check` passes on all modified files
- [ ] Table has proper indexes (`user_id`, `reference_id`), constraints, and enum types
- [ ] Downgrade drops table and both enum types cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)