### PR TITLE
fix(security): wrap raw SQL with text() in billing modules [REN-68]

### DIFF
--- a/core/billing/invoice/cron_monthly.py
+++ b/core/billing/invoice/cron_monthly.py
@@ -2,15 +2,16 @@ import asyncio
 import os
 
 import postmarker
-from db import async_session
+from db import async_session  # TODO(REN-87): Migrate from legacy db module to core.database
 from invoice_builder import PERIOD, build
+from sqlalchemy import text
 
 client = postmarker.PostmarkClient(server_token=os.environ["POSTMARK_KEY"])
 
 
 async def main():
     async with async_session() as s:
-        rows = await s.execute("SELECT id,email FROM creators")
+        rows = await s.execute(text("SELECT id,email FROM creators"))
     for r in rows:
         url, total = await build(r.id)
         client.emails.send(

--- a/core/billing/invoice/invoice_builder.py
+++ b/core/billing/invoice/invoice_builder.py
@@ -4,7 +4,8 @@ import os
 import jinja2
 import weasyprint
 from boto3 import client as s3
-from db import async_session
+from db import async_session  # TODO(REN-87): Migrate from legacy db module to core.database
+from sqlalchemy import text
 
 S3 = s3(
     "s3",
@@ -19,7 +20,7 @@ PERIOD = (datetime.date.today().replace(day=1) - datetime.timedelta(days=1)).str
 async def build(account_id: str):
     async with async_session() as s:
         rows = await s.execute(
-            """SELECT created_at, delta_usd FROM ledger_entries WHERE account_id=:a AND date_trunc('month', created_at)=date_trunc('month', now()-interval '1 month')""",
+            text("SELECT created_at, delta_usd FROM ledger_entries WHERE account_id=:a AND date_trunc('month', created_at)=date_trunc('month', now()-interval '1 month')"),
             {"a": account_id},
         )
         items = [

--- a/core/billing/stripe/ledger/credit.py
+++ b/core/billing/stripe/ledger/credit.py
@@ -1,4 +1,4 @@
-from db import Ledger, async_session
+from db import Ledger, async_session  # TODO(REN-87): Migrate from legacy db module to core.database
 
 
 async def credit(creator_id: str, amount: float):

--- a/core/billing/webhook.py
+++ b/core/billing/webhook.py
@@ -1,4 +1,8 @@
-from db import Ledger, UsageEvent, async_session
+from db import (  # TODO(REN-87): Migrate from legacy db module to core.database
+    Ledger,
+    UsageEvent,
+    async_session,
+)
 from fastapi import APIRouter, Request
 from sqlalchemy import func, select
 


### PR DESCRIPTION
## Summary
- Wrap raw SQL strings with `sqlalchemy.text()` in `cron_monthly.py` and `invoice_builder.py` to remediate OWASP A03 (Injection)
- Add `TODO(REN-87)` comments to all 4 legacy billing files flagging the `from db import` migration
- No behavioral changes -- ORM-based files (`webhook.py`, `credit.py`) receive only the TODO comment

## Security Validation
- [x] Zero raw SQL strings without `text()` wrapper (grep verified)
- [x] `ruff check core/billing/` passes with zero errors
- [x] No secrets in diff
- [x] Legacy `from db import` patterns left intact (migration tracked in REN-87)

## Files Changed
| File | Risk | Change |
|------|------|--------|
| `core/billing/invoice/cron_monthly.py` | HIGH | Added `text()` wrapper + TODO |
| `core/billing/invoice/invoice_builder.py` | MEDIUM | Added `text()` wrapper + TODO |
| `core/billing/webhook.py` | LOW | TODO comment only (ORM is safe) |
| `core/billing/stripe/ledger/credit.py` | LOW | TODO comment only (ORM is safe) |

## Test plan
- [x] `cron_monthly.py` uses `text()` for SQL queries
- [x] `invoice_builder.py` uses `text()` for parameterized SQL queries
- [x] `ruff check` passes on all modified files
- [x] No new raw SQL strings without `text()` wrapper
- [x] No secrets committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)