### PR TITLE
feat(observability): add request ID correlation middleware [REN-71]

### DIFF
--- a/core/main.py
+++ b/core/main.py
@@ -29,6 +29,7 @@ from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoin
 from core.api.v1.router import api_v1_router
 from core.config import get_settings
 from core.database import engine
+from core.middleware.request_id import RequestIdMiddleware
 
 logger = structlog.get_logger(__name__)
 
@@ -117,6 +118,9 @@ def create_app() -> FastAPI:
 
     # Security headers middleware (wraps CORS so it runs on all responses)
     application.add_middleware(SecurityHeadersMiddleware)
+
+    # Request ID must be outermost (added last) so all logging has request_id
+    application.add_middleware(RequestIdMiddleware)
 
     # Include API v1 routes
     application.include_router(api_v1_router)

--- a/core/middleware/__init__.py
+++ b/core/middleware/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2025 ByBren, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Core middleware package."""

--- a/core/middleware/request_id.py
+++ b/core/middleware/request_id.py
@@ -1,0 +1,66 @@
+# Copyright 2025 ByBren, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Request ID correlation middleware.
+
+Generates a unique UUID for each request, binds it to the structlog
+context via contextvars, and includes it in the response X-Request-ID header.
+Accepts an incoming X-Request-ID header from the client to support
+distributed tracing across services.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+import structlog
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+
+if TYPE_CHECKING:
+    from fastapi import Request, Response
+
+logger = structlog.get_logger(__name__)
+
+_REQUEST_ID_HEADER = "X-Request-ID"
+
+
+class RequestIdMiddleware(BaseHTTPMiddleware):
+    """Middleware that generates and propagates request IDs.
+
+    For each incoming request:
+    1. Reads the client-provided X-Request-ID header, or generates a new UUID.
+    2. Clears and rebinds structlog contextvars so every log statement
+       within the request lifecycle includes ``request_id``.
+    3. Stores the ID on ``request.state.request_id`` for route handlers.
+    4. Sets the X-Request-ID response header for client correlation.
+    """
+
+    async def dispatch(
+        self, request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:
+        # Use client-provided ID if present, otherwise generate
+        request_id = request.headers.get(_REQUEST_ID_HEADER) or str(uuid.uuid4())
+
+        # Bind to structlog context (available to all log calls in this request)
+        structlog.contextvars.clear_contextvars()
+        structlog.contextvars.bind_contextvars(request_id=request_id)
+
+        # Store on request.state for access in route handlers
+        request.state.request_id = request_id
+
+        response = await call_next(request)
+        response.headers[_REQUEST_ID_HEADER] = request_id
+
+        return response


### PR DESCRIPTION
## Summary
- Add `RequestIdMiddleware` generating a UUID per request and binding it to structlog contextvars so all log statements automatically include `request_id`
- Return `X-Request-ID` in response headers for client-side correlation
- Accept client-provided `X-Request-ID` header to support distributed tracing across edge nodes and gateway (OWASP A09 remediation)
- Store request ID on `request.state` for direct access in route handlers

## Test plan
- [ ] Responses include `X-Request-ID` header with a valid UUID
- [ ] Logs include `request_id` field automatically (via structlog contextvars)
- [ ] Client-provided `X-Request-ID` is echoed back unchanged
- [ ] Missing `X-Request-ID` generates a new UUID (not empty)
- [ ] `ruff check` passes on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)