### PR TITLE
feat(ledger): add deduct_credits and get_history [REN-77]

### DIFF
--- a/core/ledger/service.py
+++ b/core/ledger/service.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Credit ledger service for allocating and querying credits.
+"""Credit ledger service for allocating, deducting, and querying credits.
 
 All operations are atomic and idempotent. Uses the CreditLedgerEntry model
 with SELECT FOR UPDATE row locking for concurrent safety.
@@ -35,6 +35,19 @@ if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
 
 logger = structlog.get_logger(__name__)
+
+
+class InsufficientCreditsError(Exception):
+    """Raised when a debit would cause a negative balance."""
+
+    def __init__(self, user_id: uuid.UUID, requested: Decimal, available: Decimal) -> None:
+        self.user_id = user_id
+        self.requested = requested
+        self.available = available
+        super().__init__(
+            f"Insufficient credits for user {user_id}: "
+            f"requested {requested}, available {available}"
+        )
 
 
 async def allocate_credits(
@@ -149,3 +162,139 @@ async def get_balance(
     )
     last_entry = result.scalar_one_or_none()
     return last_entry.balance_after if last_entry else Decimal("0.0000")
+
+
+async def deduct_credits(
+    session: AsyncSession,
+    user_id: uuid.UUID,
+    amount: Decimal,
+    source: TransactionSource,
+    reference_id: str,
+    description: str | None = None,
+) -> CreditLedgerEntry:
+    """Deduct credits from a user's account.
+
+    Idempotent: if a DEBIT entry with the same reference_id already exists,
+    returns the existing entry without creating a duplicate.
+
+    Args:
+        session: Async database session.
+        user_id: UUID of the user to debit.
+        amount: Positive debit amount.
+        source: Source of the debit (USAGE, ADJUSTMENT).
+        reference_id: External reference for idempotency.
+        description: Optional human-readable description.
+
+    Returns:
+        The created (or existing) CreditLedgerEntry.
+
+    Raises:
+        ValueError: If amount is zero or negative.
+        InsufficientCreditsError: If balance would go negative.
+    """
+    if amount <= 0:
+        msg = "Debit amount must be positive"
+        raise ValueError(msg)
+
+    # Check for existing entry (idempotency)
+    existing = await session.execute(
+        select(CreditLedgerEntry).where(
+            CreditLedgerEntry.reference_id == reference_id,
+            CreditLedgerEntry.direction == TransactionDirection.DEBIT,
+        )
+    )
+    existing_entry = existing.scalar_one_or_none()
+    if existing_entry is not None:
+        logger.info(
+            "credit_deduction_idempotent",
+            reference_id=reference_id,
+            user_id=str(user_id),
+        )
+        return existing_entry
+
+    # Get current balance (last entry's balance_after, or 0 if first).
+    # Use FOR UPDATE to prevent concurrent balance reads.
+    last_entry_result = await session.execute(
+        select(CreditLedgerEntry)
+        .where(CreditLedgerEntry.user_id == user_id)
+        .order_by(CreditLedgerEntry.created_at.desc())
+        .limit(1)
+        .with_for_update()
+    )
+    last_entry = last_entry_result.scalar_one_or_none()
+    current_balance = last_entry.balance_after if last_entry else Decimal("0.0000")
+
+    new_balance = current_balance - amount
+    if new_balance < 0:
+        raise InsufficientCreditsError(
+            user_id=user_id,
+            requested=amount,
+            available=current_balance,
+        )
+
+    entry = CreditLedgerEntry(
+        user_id=user_id,
+        amount=amount,
+        direction=TransactionDirection.DEBIT,
+        source=source,
+        reference_id=reference_id,
+        balance_after=new_balance,
+        description=description,
+    )
+    session.add(entry)
+
+    try:
+        await session.flush()
+    except IntegrityError:
+        # Race condition: another transaction created the entry first.
+        await session.rollback()
+        existing = await session.execute(
+            select(CreditLedgerEntry).where(
+                CreditLedgerEntry.reference_id == reference_id,
+                CreditLedgerEntry.direction == TransactionDirection.DEBIT,
+            )
+        )
+        return existing.scalar_one()
+
+    logger.info(
+        "credits_deducted",
+        user_id=str(user_id),
+        amount=str(amount),
+        source=source.value,
+        reference_id=reference_id,
+        new_balance=str(new_balance),
+    )
+    return entry
+
+
+_MAX_HISTORY_LIMIT = 100
+
+
+async def get_history(
+    session: AsyncSession,
+    user_id: uuid.UUID,
+    limit: int = 50,
+    offset: int = 0,
+) -> list[CreditLedgerEntry]:
+    """Return credit ledger entries for a user, newest first.
+
+    Args:
+        session: Async database session.
+        user_id: UUID of the user whose history to retrieve.
+        limit: Maximum number of entries to return (default 50, max 100).
+        offset: Number of entries to skip for pagination.
+
+    Returns:
+        List of CreditLedgerEntry ordered by created_at descending.
+    """
+    # Silently clamp limit to the allowed maximum.
+    clamped_limit = min(limit, _MAX_HISTORY_LIMIT)
+
+    result = await session.execute(
+        select(CreditLedgerEntry)
+        .where(CreditLedgerEntry.user_id == user_id)
+        .order_by(CreditLedgerEntry.created_at.desc())
+        .limit(clamped_limit)
+        .offset(offset)
+    )
+    return list(result.scalars().all())

--- a/tests/test_ledger_service.py
+++ b/tests/test_ledger_service.py
@@ -1,0 +1,222 @@
+# Copyright 2025 ByBren, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the credit ledger service (deduct_credits and get_history)."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+import pytest
+
+from core.ledger.service import (
+    InsufficientCreditsError,
+    allocate_credits,
+    deduct_credits,
+    get_history,
+)
+from core.models.base import TransactionDirection, TransactionSource
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from core.models.base import User
+
+
+# ---------------------------------------------------------------------------
+# deduct_credits tests
+# ---------------------------------------------------------------------------
+
+
+async def test_deduct_credits_basic(db_session: AsyncSession, test_user: User) -> None:
+    """Allocate 100, deduct 30, verify balance_after=70."""
+    await allocate_credits(
+        session=db_session,
+        user_id=test_user.id,
+        amount=Decimal("100.0000"),
+        source=TransactionSource.STRIPE,
+        reference_id="alloc-basic-100",
+        description="Initial allocation",
+    )
+
+    entry = await deduct_credits(
+        session=db_session,
+        user_id=test_user.id,
+        amount=Decimal("30.0000"),
+        source=TransactionSource.USAGE,
+        reference_id="deduct-basic-30",
+        description="Render usage",
+    )
+
+    assert entry.direction == TransactionDirection.DEBIT
+    assert entry.amount == Decimal("30.0000")
+    assert entry.balance_after == Decimal("70.0000")
+    assert entry.user_id == test_user.id
+    assert entry.source == TransactionSource.USAGE
+    assert entry.reference_id == "deduct-basic-30"
+
+
+async def test_deduct_credits_idempotent(db_session: AsyncSession, test_user: User) -> None:
+    """Same reference_id returns existing entry without creating a duplicate."""
+    await allocate_credits(
+        session=db_session,
+        user_id=test_user.id,
+        amount=Decimal("100.0000"),
+        source=TransactionSource.STRIPE,
+        reference_id="alloc-idemp-100",
+    )
+
+    first = await deduct_credits(
+        session=db_session,
+        user_id=test_user.id,
+        amount=Decimal("25.0000"),
+        source=TransactionSource.USAGE,
+        reference_id="deduct-idemp-25",
+    )
+
+    second = await deduct_credits(
+        session=db_session,
+        user_id=test_user.id,
+        amount=Decimal("25.0000"),
+        source=TransactionSource.USAGE,
+        reference_id="deduct-idemp-25",
+    )
+
+    assert first.id == second.id
+    assert second.balance_after == Decimal("75.0000")
+
+
+async def test_deduct_credits_insufficient(db_session: AsyncSession, test_user: User) -> None:
+    """Raises InsufficientCreditsError when balance would go negative."""
+    await allocate_credits(
+        session=db_session,
+        user_id=test_user.id,
+        amount=Decimal("10.0000"),
+        source=TransactionSource.STRIPE,
+        reference_id="alloc-insuff-10",
+    )
+
+    with pytest.raises(InsufficientCreditsError) as exc_info:
+        await deduct_credits(
+            session=db_session,
+            user_id=test_user.id,
+            amount=Decimal("50.0000"),
+            source=TransactionSource.USAGE,
+            reference_id="deduct-insuff-50",
+        )
+
+    assert exc_info.value.requested == Decimal("50.0000")
+    assert exc_info.value.available == Decimal("10.0000")
+    assert exc_info.value.user_id == test_user.id
+
+
+async def test_deduct_credits_zero_or_negative(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    """Raises ValueError for zero or negative amounts."""
+    with pytest.raises(ValueError, match="Debit amount must be positive"):
+        await deduct_credits(
+            session=db_session,
+            user_id=test_user.id,
+            amount=Decimal("0"),
+            source=TransactionSource.USAGE,
+            reference_id="deduct-zero",
+        )
+
+    with pytest.raises(ValueError, match="Debit amount must be positive"):
+        await deduct_credits(
+            session=db_session,
+            user_id=test_user.id,
+            amount=Decimal("-5.0000"),
+            source=TransactionSource.USAGE,
+            reference_id="deduct-neg",
+        )
+
+
+# ---------------------------------------------------------------------------
+# get_history tests
+# ---------------------------------------------------------------------------
+
+
+async def test_get_history_default(db_session: AsyncSession, test_user: User) -> None:
+    """Returns entries in created_at DESC order."""
+    await allocate_credits(
+        session=db_session,
+        user_id=test_user.id,
+        amount=Decimal("200.0000"),
+        source=TransactionSource.STRIPE,
+        reference_id="alloc-hist-200",
+    )
+    await deduct_credits(
+        session=db_session,
+        user_id=test_user.id,
+        amount=Decimal("50.0000"),
+        source=TransactionSource.USAGE,
+        reference_id="deduct-hist-50",
+    )
+    await allocate_credits(
+        session=db_session,
+        user_id=test_user.id,
+        amount=Decimal("25.0000"),
+        source=TransactionSource.ADJUSTMENT,
+        reference_id="alloc-hist-25",
+    )
+
+    history = await get_history(session=db_session, user_id=test_user.id)
+
+    assert len(history) == 3
+    # Newest first
+    assert history[0].reference_id == "alloc-hist-25"
+    assert history[1].reference_id == "deduct-hist-50"
+    assert history[2].reference_id == "alloc-hist-200"
+    # Verify ordering by created_at
+    for i in range(len(history) - 1):
+        assert history[i].created_at >= history[i + 1].created_at
+
+
+async def test_get_history_pagination(db_session: AsyncSession, test_user: User) -> None:
+    """Limit and offset work correctly for pagination."""
+    # Create 5 entries
+    for i in range(5):
+        await allocate_credits(
+            session=db_session,
+            user_id=test_user.id,
+            amount=Decimal("10.0000"),
+            source=TransactionSource.STRIPE,
+            reference_id=f"alloc-page-{i}",
+        )
+
+    # First page: limit=2, offset=0
+    page1 = await get_history(session=db_session, user_id=test_user.id, limit=2, offset=0)
+    assert len(page1) == 2
+
+    # Second page: limit=2, offset=2
+    page2 = await get_history(session=db_session, user_id=test_user.id, limit=2, offset=2)
+    assert len(page2) == 2
+
+    # Verify no overlap
+    page1_ids = {e.id for e in page1}
+    page2_ids = {e.id for e in page2}
+    assert page1_ids.isdisjoint(page2_ids)
+
+    # Third page: limit=2, offset=4 -- only 1 remaining
+    page3 = await get_history(session=db_session, user_id=test_user.id, limit=2, offset=4)
+    assert len(page3) == 1
+
+
+async def test_get_history_empty(db_session: AsyncSession, test_user: User) -> None:
+    """Returns empty list for user with no entries."""
+    history = await get_history(session=db_session, user_id=test_user.id)
+    assert history == []


### PR DESCRIPTION
## Summary
- Add `deduct_credits()` service function with idempotency, SELECT FOR UPDATE locking, and custom `InsufficientCreditsError` exception
- Add `get_history()` for paginated transaction history (limit/offset, max 100)
- 7 unit tests covering debit operations, idempotency, insufficient balance, and history queries

## Test plan
- [x] `test_deduct_credits_basic` — allocate 100, deduct 30, verify balance=70
- [x] `test_deduct_credits_idempotent` — same reference_id returns existing entry
- [x] `test_deduct_credits_insufficient` — raises InsufficientCreditsError
- [x] `test_deduct_credits_zero_or_negative` — raises ValueError
- [x] `test_get_history_default` — created_at DESC ordering
- [x] `test_get_history_pagination` — limit/offset correctness
- [x] `test_get_history_empty` — returns [] for new user

🤖 Generated with [Claude Code](https://claude.com/claude-code)