### PR TITLE
feat(credits): add balance, history, and deduct API endpoints [REN-78]

### DIFF
--- a/core/api/v1/credits.py
+++ b/core/api/v1/credits.py
@@ -1,0 +1,219 @@
+# Copyright 2026 ByBren, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Credit API endpoints for balance queries, history, and deductions.
+
+Provides authenticated endpoints for users to check their credit balance,
+view transaction history, and deduct credits for usage.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal, InvalidOperation
+from typing import TYPE_CHECKING
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, ConfigDict
+
+from core.auth.jwt import get_current_user
+from core.database import get_db_session
+from core.ledger.service import InsufficientCreditsError, deduct_credits, get_balance, get_history
+from core.models.base import TransactionSource
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from core.models.base import User
+
+logger = structlog.get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Request / Response Schemas
+# ---------------------------------------------------------------------------
+
+
+class BalanceResponse(BaseModel):
+    """Credit balance response."""
+
+    balance: str
+    user_id: str
+
+
+class LedgerEntryResponse(BaseModel):
+    """Single ledger entry in history responses."""
+
+    id: str
+    amount: str
+    direction: str
+    source: str
+    reference_id: str
+    balance_after: str
+    description: str | None
+    created_at: str
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class HistoryResponse(BaseModel):
+    """Paginated credit history response."""
+
+    entries: list[LedgerEntryResponse]
+    count: int
+
+
+class DeductRequest(BaseModel):
+    """Credit deduction request body."""
+
+    amount: str
+    reference_id: str
+    description: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Router
+# ---------------------------------------------------------------------------
+
+router = APIRouter(prefix="/credits")
+
+
+# ---------------------------------------------------------------------------
+# GET /credits/balance
+# ---------------------------------------------------------------------------
+
+
+@router.get("/balance", response_model=BalanceResponse)
+async def credit_balance(
+    current_user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db_session),
+) -> BalanceResponse:
+    """Return the current credit balance for the authenticated user."""
+    balance = await get_balance(session=session, user_id=current_user.id)
+    logger.info("balance_queried", user_id=str(current_user.id), balance=str(balance))
+    return BalanceResponse(
+        balance=str(balance),
+        user_id=str(current_user.id),
+    )
+
+
+# ---------------------------------------------------------------------------
+# GET /credits/history
+# ---------------------------------------------------------------------------
+
+
+@router.get("/history", response_model=HistoryResponse)
+async def credit_history(
+    limit: int = Query(default=50, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+    current_user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db_session),
+) -> HistoryResponse:
+    """Return paginated credit transaction history for the authenticated user."""
+    entries = await get_history(
+        session=session,
+        user_id=current_user.id,
+        limit=limit,
+        offset=offset,
+    )
+    entry_responses = [
+        LedgerEntryResponse(
+            id=str(entry.id),
+            amount=str(entry.amount),
+            direction=entry.direction.value,
+            source=entry.source.value,
+            reference_id=entry.reference_id,
+            balance_after=str(entry.balance_after),
+            description=entry.description,
+            created_at=entry.created_at.isoformat(),
+        )
+        for entry in entries
+    ]
+    logger.info(
+        "history_queried",
+        user_id=str(current_user.id),
+        count=len(entry_responses),
+        limit=limit,
+        offset=offset,
+    )
+    return HistoryResponse(entries=entry_responses, count=len(entry_responses))
+
+
+# ---------------------------------------------------------------------------
+# POST /credits/deduct
+# ---------------------------------------------------------------------------
+
+
+@router.post("/deduct", response_model=LedgerEntryResponse)
+async def credit_deduct(
+    payload: DeductRequest,
+    current_user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db_session),
+) -> LedgerEntryResponse | JSONResponse:
+    """Deduct credits from the authenticated user's account.
+
+    Returns 402 if the user has insufficient credits.
+    Returns 422 if the amount is not a valid positive decimal.
+    """
+    try:
+        amount = Decimal(payload.amount)
+    except InvalidOperation as err:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Invalid amount: {payload.amount}",
+        ) from err
+
+    if amount <= 0:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Amount must be a positive number",
+        )
+
+    try:
+        entry = await deduct_credits(
+            session=session,
+            user_id=current_user.id,
+            amount=amount,
+            source=TransactionSource.USAGE,
+            reference_id=payload.reference_id,
+            description=payload.description,
+        )
+    except InsufficientCreditsError as err:
+        return JSONResponse(
+            status_code=status.HTTP_402_PAYMENT_REQUIRED,
+            content={
+                "detail": "Insufficient credits",
+                "available": str(err.available),
+                "requested": str(err.requested),
+            },
+        )
+
+    await session.commit()
+
+    logger.info(
+        "credits_deducted_via_api",
+        user_id=str(current_user.id),
+        amount=str(amount),
+        reference_id=payload.reference_id,
+    )
+    return LedgerEntryResponse(
+        id=str(entry.id),
+        amount=str(entry.amount),
+        direction=entry.direction.value,
+        source=entry.source.value,
+        reference_id=entry.reference_id,
+        balance_after=str(entry.balance_after),
+        description=entry.description,
+        created_at=entry.created_at.isoformat(),
+    )

--- a/core/api/v1/router.py
+++ b/core/api/v1/router.py
@@ -14,13 +14,13 @@
 
 """API v1 router aggregating all sub-routers.
 
-Includes health checks and authentication. Billing and fleet sub-routers
-will be added as they are implemented.
+Includes health checks, authentication, credits, and billing.
 """
 
 from fastapi import APIRouter
 
 from core.api.v1.auth import router as auth_router
+from core.api.v1.credits import router as credits_router
 from core.api.v1.health import router as health_router
 from core.billing.stripe.stripe_webhook import router as stripe_webhook_router
 
@@ -34,3 +34,6 @@ api_v1_router.include_router(auth_router, tags=["auth"])
 
 # Billing webhooks
 api_v1_router.include_router(stripe_webhook_router, tags=["billing"])
+
+# Credits
+api_v1_router.include_router(credits_router, tags=["credits"])

--- a/tests/test_credit_api.py
+++ b/tests/test_credit_api.py
@@ -1,0 +1,280 @@
+# Copyright 2026 ByBren, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the credit API endpoints (balance, history, deduct)."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from core.auth.jwt import create_access_token
+from core.ledger.service import allocate_credits, deduct_credits
+from core.models.base import TransactionSource
+
+if TYPE_CHECKING:
+    from httpx import AsyncClient
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from core.models.base import User
+
+
+# ---------------------------------------------------------------------------
+# Mock the Redis-backed token blacklist for all tests in this module.
+# verify_token() is async and checks the blacklist, so we must mock it.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def mock_blacklist():
+    with patch("core.auth.jwt.token_blacklist") as mock_bl:
+        mock_bl.is_revoked = AsyncMock(return_value=False)
+        yield mock_bl
+
+
+# ---------------------------------------------------------------------------
+# Helper: auth headers
+# ---------------------------------------------------------------------------
+
+
+def _auth_headers(user: User) -> dict[str, str]:
+    token = create_access_token({"sub": str(user.id)})
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/credits/balance
+# ---------------------------------------------------------------------------
+
+
+async def test_get_balance_empty(
+    client: AsyncClient,
+    test_user: User,
+) -> None:
+    """New user with no ledger entries has a zero balance."""
+    resp = await client.get(
+        "/api/v1/credits/balance",
+        headers=_auth_headers(test_user),
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["balance"] == "0.0000"
+    assert data["user_id"] == str(test_user.id)
+
+
+async def test_get_balance_after_allocation(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    test_user: User,
+) -> None:
+    """Balance reflects credits allocated via the service layer."""
+    await allocate_credits(
+        session=db_session,
+        user_id=test_user.id,
+        amount=Decimal("250.5000"),
+        source=TransactionSource.STRIPE,
+        reference_id="test-alloc-balance-250",
+    )
+    await db_session.flush()
+
+    resp = await client.get(
+        "/api/v1/credits/balance",
+        headers=_auth_headers(test_user),
+    )
+    assert resp.status_code == 200
+    assert resp.json()["balance"] == "250.5000"
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/credits/history
+# ---------------------------------------------------------------------------
+
+
+async def test_get_history_empty(
+    client: AsyncClient,
+    test_user: User,
+) -> None:
+    """Returns empty list for user with no ledger entries."""
+    resp = await client.get(
+        "/api/v1/credits/history",
+        headers=_auth_headers(test_user),
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["entries"] == []
+    assert data["count"] == 0
+
+
+async def test_get_history_with_entries(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    test_user: User,
+) -> None:
+    """Allocate + deduct, verify history order and count."""
+    await allocate_credits(
+        session=db_session,
+        user_id=test_user.id,
+        amount=Decimal("100.0000"),
+        source=TransactionSource.STRIPE,
+        reference_id="test-hist-alloc-100",
+    )
+    await deduct_credits(
+        session=db_session,
+        user_id=test_user.id,
+        amount=Decimal("30.0000"),
+        source=TransactionSource.USAGE,
+        reference_id="test-hist-deduct-30",
+    )
+    await db_session.flush()
+
+    resp = await client.get(
+        "/api/v1/credits/history",
+        headers=_auth_headers(test_user),
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["count"] == 2
+
+    # Newest first
+    entries = data["entries"]
+    assert entries[0]["direction"] == "DEBIT"
+    assert entries[0]["reference_id"] == "test-hist-deduct-30"
+    assert entries[1]["direction"] == "CREDIT"
+    assert entries[1]["reference_id"] == "test-hist-alloc-100"
+
+
+async def test_get_history_pagination(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    test_user: User,
+) -> None:
+    """Verify limit and offset pagination params."""
+    # Create 5 entries
+    for i in range(5):
+        await allocate_credits(
+            session=db_session,
+            user_id=test_user.id,
+            amount=Decimal("10.0000"),
+            source=TransactionSource.STRIPE,
+            reference_id=f"test-page-{i}",
+        )
+    await db_session.flush()
+
+    headers = _auth_headers(test_user)
+
+    # First page
+    resp1 = await client.get(
+        "/api/v1/credits/history?limit=2&offset=0",
+        headers=headers,
+    )
+    assert resp1.status_code == 200
+    page1 = resp1.json()
+    assert page1["count"] == 2
+
+    # Second page
+    resp2 = await client.get(
+        "/api/v1/credits/history?limit=2&offset=2",
+        headers=headers,
+    )
+    assert resp2.status_code == 200
+    page2 = resp2.json()
+    assert page2["count"] == 2
+
+    # No overlap
+    page1_ids = {e["id"] for e in page1["entries"]}
+    page2_ids = {e["id"] for e in page2["entries"]}
+    assert page1_ids.isdisjoint(page2_ids)
+
+    # Last page with only 1 remaining
+    resp3 = await client.get(
+        "/api/v1/credits/history?limit=2&offset=4",
+        headers=headers,
+    )
+    assert resp3.status_code == 200
+    assert resp3.json()["count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# POST /api/v1/credits/deduct
+# ---------------------------------------------------------------------------
+
+
+async def test_deduct_credits_success(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    test_user: User,
+) -> None:
+    """Allocate 100, deduct 30 via endpoint, verify response."""
+    await allocate_credits(
+        session=db_session,
+        user_id=test_user.id,
+        amount=Decimal("100.0000"),
+        source=TransactionSource.STRIPE,
+        reference_id="test-deduct-api-alloc-100",
+    )
+    await db_session.flush()
+
+    resp = await client.post(
+        "/api/v1/credits/deduct",
+        headers=_auth_headers(test_user),
+        json={
+            "amount": "30.0000",
+            "reference_id": "test-deduct-api-30",
+            "description": "Render job usage",
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["amount"] == "30.0000"
+    assert data["direction"] == "DEBIT"
+    assert data["source"] == "USAGE"
+    assert data["balance_after"] == "70.0000"
+    assert data["reference_id"] == "test-deduct-api-30"
+    assert data["description"] == "Render job usage"
+
+
+async def test_deduct_insufficient(
+    client: AsyncClient,
+    test_user: User,
+) -> None:
+    """Returns 402 with available/requested when balance is insufficient."""
+    resp = await client.post(
+        "/api/v1/credits/deduct",
+        headers=_auth_headers(test_user),
+        json={
+            "amount": "500.0000",
+            "reference_id": "test-deduct-insuff-500",
+        },
+    )
+    assert resp.status_code == 402
+    data = resp.json()
+    assert data["detail"] == "Insufficient credits"
+    assert "available" in data
+    assert data["requested"] == "500.0000"
+
+
+# ---------------------------------------------------------------------------
+# Authentication guard
+# ---------------------------------------------------------------------------
+
+
+async def test_unauthenticated_returns_401(
+    client: AsyncClient,
+) -> None:
+    """Requests without an auth header return 401."""
+    resp = await client.get("/api/v1/credits/balance")
+    assert resp.status_code in (401, 403)


### PR DESCRIPTION
## Summary
- `GET /api/v1/credits/balance` — authenticated balance query returning decimal string
- `GET /api/v1/credits/history` — paginated transaction history (limit/offset, max 100)
- `POST /api/v1/credits/deduct` — usage deduction with 402 on insufficient credits
- All endpoints require Bearer auth via `get_current_user` dependency
- 8 integration tests with blacklist mock fixture

## Test plan
- [x] `test_get_balance_empty` — new user returns "0.0000"
- [x] `test_get_balance_after_allocation` — reflects allocated credits
- [x] `test_get_history_empty` — empty list, count=0
- [x] `test_get_history_with_entries` — correct ordering (newest first)
- [x] `test_get_history_pagination` — limit/offset no overlap
- [x] `test_deduct_credits_success` — allocate 100, deduct 30, verify response
- [x] `test_deduct_insufficient` — 402 with available/requested
- [x] `test_unauthenticated_returns_401` — no auth → 401/403

🤖 Generated with [Claude Code](https://claude.com/claude-code)