### PR TITLE
fix: resolve 42 regression failures in full test suite [REN-63]

### DIFF
--- a/core/auth/blacklist.py
+++ b/core/auth/blacklist.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import datetime
 
+import redis.asyncio as aioredis
 import structlog
 
 from core.config import get_settings
@@ -63,8 +64,6 @@ class TokenBlacklist:
             True if the token was successfully blacklisted, False if
             the token is already expired or Redis is unavailable.
         """
-        import redis.asyncio as aioredis
-
         now = datetime.datetime.now(tz=datetime.UTC)
 
         # Ensure expires_at is timezone-aware for comparison
@@ -103,8 +102,6 @@ class TokenBlacklist:
             True if the token is blacklisted, False if it is not or
             if Redis is unavailable (fail-open).
         """
-        import redis.asyncio as aioredis
-
         settings = get_settings()
         key = f"{_KEY_PREFIX}{jti}"
 

--- a/core/auth/jwt.py
+++ b/core/auth/jwt.py
@@ -32,6 +32,7 @@ from jose import JWTError, jwt
 from pydantic import BaseModel
 from sqlalchemy import select
 
+from core.auth.blacklist import token_blacklist
 from core.config import get_settings
 from core.database import get_db_session
 from core.models.base import User
@@ -157,8 +158,6 @@ async def verify_token(token: str) -> TokenPayload:
         raise credentials_exception from err
 
     # Check blacklist (after decode, before return)
-    from core.auth.blacklist import token_blacklist
-
     if payload_data.jti and await token_blacklist.is_revoked(payload_data.jti):
         logger.warning("revoked_token_used", jti=payload_data.jti)
         raise credentials_exception
@@ -197,8 +196,20 @@ async def get_current_user(
             headers={"WWW-Authenticate": "Bearer"},
         )
 
+    import uuid as _uuid
+
+    try:
+        user_id = _uuid.UUID(token_data.sub)
+    except (ValueError, AttributeError):
+        logger.warning("invalid_user_id_format", user_id=token_data.sub)
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid user ID",
+            headers={"WWW-Authenticate": "Bearer"},
+        ) from None
+
     result = await session.execute(
-        select(User).where(User.id == token_data.sub),
+        select(User).where(User.id == user_id),
     )
     user = result.scalar_one_or_none()
 

--- a/core/database.py
+++ b/core/database.py
@@ -42,6 +42,17 @@ class Base(DeclarativeBase):
     """
 
 
+def _utcnow() -> datetime.datetime:
+    """Return current UTC time with microsecond precision.
+
+    Used as Python-level default for timestamps. This ensures entries
+    created in quick succession (e.g. in tests with SQLite) have
+    distinct timestamps, unlike server_default=func.now() which may
+    have only second-level precision in SQLite.
+    """
+    return datetime.datetime.now(tz=datetime.UTC)
+
+
 class TimestampMixin:
     """Mixin providing created_at and updated_at timestamp columns.
 
@@ -51,13 +62,15 @@ class TimestampMixin:
 
     created_at: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True),
+        default=_utcnow,
         server_default=func.now(),
         nullable=False,
     )
     updated_at: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True),
+        default=_utcnow,
         server_default=func.now(),
-        onupdate=func.now(),
+        onupdate=_utcnow,
         nullable=False,
     )
 
@@ -81,15 +94,18 @@ def _create_engine() -> AsyncEngine:
     """Create an async SQLAlchemy engine from application settings.
 
     Pool size and overflow are configured from environment variables.
-    Echo is enabled in debug mode for SQL logging.
+    SQLite (used in tests) does not support pool_size/max_overflow,
+    so those parameters are omitted for sqlite:// URLs.
     """
     settings = get_settings()
-    return create_async_engine(
-        settings.database_url,
-        pool_size=settings.db_pool_size,
-        max_overflow=settings.db_max_overflow,
-        echo=settings.app_debug,
-    )
+    kwargs: dict[str, object] = {"echo": settings.app_debug}
+
+    # SQLite uses StaticPool and doesn't accept pool_size/max_overflow.
+    if not settings.database_url.startswith("sqlite"):
+        kwargs["pool_size"] = settings.db_pool_size
+        kwargs["max_overflow"] = settings.db_max_overflow
+
+    return create_async_engine(settings.database_url, **kwargs)
 
 
 # Module-level engine and session factory.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,12 +22,13 @@ dependencies = [
     "alembic>=1.14.0,<2.0",
 
     # Configuration & validation
-    "pydantic>=2.10.0,<3.0",
+    "pydantic[email]>=2.10.0,<3.0",
     "pydantic-settings>=2.7.0,<3.0",
 
     # Authentication
     "python-jose[cryptography]>=3.3.0,<4.0",
     "passlib[bcrypt]>=1.7.4,<2.0",
+    "bcrypt>=4.0,<4.1",
 
     # Payments
     "stripe>=11.0.0,<12.0",

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -195,10 +195,10 @@ class TestTokenVerification:
 class TestAuthenticatedEndpoints:
     """Test endpoint authentication via get_current_user dependency."""
 
-    async def test_missing_auth_header_returns_403(self, auth_client: AsyncClient):
-        """HTTPBearer returns 403 when no Authorization header is present."""
+    async def test_missing_auth_header_returns_unauthorized(self, auth_client: AsyncClient):
+        """Missing Authorization header returns 401 or 403 depending on FastAPI version."""
         response = await auth_client.get("/test-auth")
-        assert response.status_code == 403
+        assert response.status_code in (401, 403)
 
     async def test_invalid_token_returns_401(self, auth_client: AsyncClient):
         response = await auth_client.get(


### PR DESCRIPTION
## Summary
Full regression test gate run discovered **42 test failures** (36 errors + 6 failures) across the 83-test suite. All 5 waves of Cycle 14 work had never been validated together.

**Root causes found and fixed:**
- `bcrypt>=4.1` broke passlib's internal wrap detection → pinned `bcrypt<4.1`
- `pydantic[email]` missing → `EmailStr` validation crashed at import
- `token_blacklist` imported locally inside `verify_token()` → mock path `core.auth.jwt.token_blacklist` didn't resolve
- `redis.asyncio` imported locally in blacklist → same mock path issue
- `token_data.sub` is a string but `User.id` is UUID → SQLite `.hex` crash on string comparison
- SQLite `CURRENT_TIMESTAMP` has second precision → rapid inserts got same timestamp → ordering nondeterministic
- `pool_size`/`max_overflow` not supported by SQLite → engine creation crashed in tests
- FastAPI 0.115+ returns 401 (not 403) for missing auth header

## Test plan
- [x] All 83 tests pass in Python 3.11 Docker container
- [x] `ruff check .` passes
- [x] Docker production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)